### PR TITLE
fix: failing migration due to lack of permissions

### DIFF
--- a/charts/catalog/templates/migration-job.yaml
+++ b/charts/catalog/templates/migration-job.yaml
@@ -36,7 +36,7 @@ rules:
     verbs:     ["list"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs:     ["get", "update"]
+    verbs:     ["get", "update", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs:     ["delete"]


### PR DESCRIPTION



This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
When upgrading the service-catalog, the migration fails with following error: Error: when removing owner references from secrets: secrets "xxx" is forbidden: cannot set an ownerRef on a resource you can't delete.

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #17

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
